### PR TITLE
Miscelaneous

### DIFF
--- a/Config.xcconfig
+++ b/Config.xcconfig
@@ -12,7 +12,7 @@
 
 
 KEANU_APP_BUNDLE_ID = im.zom.messenger
-KEANU_EXT_BUNDLE_ID =
+KEANU_EXT_BUNDLE_ID = im.zom.messenger.ShareExtension
 KEANU_APP_GROUP = group.im.zom.messenger
 
 DEVELOPMENT_TEAM = 9SV9LPRC42

--- a/ShareExtension/ShareExtension.entitlements
+++ b/ShareExtension/ShareExtension.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.im.zom.messenger</string>
+		<string>$(KEANU_APP_GROUP)</string>
 	</array>
 </dict>
 </plist>

--- a/Zom 2.xcodeproj/project.pbxproj
+++ b/Zom 2.xcodeproj/project.pbxproj
@@ -586,8 +586,8 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 9SV9LPRC42;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "$(DEVELOPMENT_TEAM)";
 				INFOPLIST_FILE = ShareExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -595,8 +595,9 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = im.zom.messenger.ShareExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(KEANU_EXT_BUNDLE_ID)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "$(PROVISIONING_PROFILE_SPECIFIER_SHARE_EXTENSION_DEV)";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "Zom 2/Zom2-Bridging-Header.h";
 				SWIFT_VERSION = 4.2;
@@ -610,8 +611,8 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 9SV9LPRC42;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "$(DEVELOPMENT_TEAM)";
 				INFOPLIST_FILE = ShareExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -619,8 +620,9 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = im.zom.messenger.ShareExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(KEANU_EXT_BUNDLE_ID)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "$(PROVISIONING_PROFILE_SPECIFIER_SHARE_EXTENSION_RELEASE)";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "Zom 2/Zom2-Bridging-Header.h";
 				SWIFT_VERSION = 4.2;
@@ -755,16 +757,16 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Zom 2/Zom 2.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 9SV9LPRC42;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "$(DEVELOPMENT_TEAM)";
 				INFOPLIST_FILE = "Zom 2/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = im.zom.messenger;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(KEANU_APP_BUNDLE_ID)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "$(PROVISIONING_PROFILE_SPECIFIER_MAIN_DEV)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Zom 2/Zom2-Bridging-Header.h";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -778,16 +780,16 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Zom 2/Zom 2.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 9SV9LPRC42;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "$(DEVELOPMENT_TEAM)";
 				INFOPLIST_FILE = "Zom 2/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = im.zom.messenger;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(KEANU_APP_BUNDLE_ID)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "$(PROVISIONING_PROFILE_SPECIFIER_MAIN_RELEASE)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Zom 2/Zom2-Bridging-Header.h";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/Zom 2.xcodeproj/project.pbxproj
+++ b/Zom 2.xcodeproj/project.pbxproj
@@ -724,7 +724,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5AC836065B73D12EEE89CC26 /* Pods-Zom 2.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Zom 2/Zom 2.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -748,7 +747,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6DE7F91A6F9B83E63B8E827A /* Pods-Zom 2.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Zom 2/Zom 2.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";

--- a/Zom 2.xcodeproj/project.pbxproj
+++ b/Zom 2.xcodeproj/project.pbxproj
@@ -96,6 +96,12 @@
 		92C8BCCF21FF62A9003D4EE3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		92C8BCDD21FF6FC9003D4EE3 /* Zom2-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Zom2-Bridging-Header.h"; sourceTree = "<group>"; };
 		92C8BCDE21FF8CDA003D4EE3 /* Zom 2.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Zom 2.entitlements"; sourceTree = "<group>"; };
+		A08CB6942243AB570003876C /* Podfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Podfile; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		A08CB6962243AB570003876C /* use_android_strings_in_zom.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = use_android_strings_in_zom.sh; sourceTree = "<group>"; };
+		A08CB6972243AB570003876C /* stringtool.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = stringtool.sh; sourceTree = "<group>"; };
+		A08CB6982243AB570003876C /* genstrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = genstrings.swift; sourceTree = "<group>"; };
+		A08CB6992243AB570003876C /* genstrings.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = genstrings.sh; sourceTree = "<group>"; };
+		A08CB69A2243AB570003876C /* Podfile.lock */ = {isa = PBXFileReference; lastKnownFileType = text; path = Podfile.lock; sourceTree = "<group>"; };
 		BE0B501F5A3C23A8E95BDE43 /* Pods-ShareExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ShareExtension.release.xcconfig"; path = "Pods/Target Support Files/Pods-ShareExtension/Pods-ShareExtension.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -181,6 +187,7 @@
 		92C8BCB721FF62A5003D4EE3 = {
 			isa = PBXGroup;
 			children = (
+				A08CB6932243AB2D0003876C /* Build */,
 				401114E4223B18F500D2CC02 /* Shared */,
 				92C8BCC221FF62A5003D4EE3 /* Zom 2 */,
 				401114D2223B0F7800D2CC02 /* ShareExtension */,
@@ -221,6 +228,27 @@
 				924E71342201F54D00B398DD /* Stickers */,
 			);
 			path = "Zom 2";
+			sourceTree = "<group>";
+		};
+		A08CB6932243AB2D0003876C /* Build */ = {
+			isa = PBXGroup;
+			children = (
+				A08CB6942243AB570003876C /* Podfile */,
+				A08CB69A2243AB570003876C /* Podfile.lock */,
+				A08CB6952243AB570003876C /* scripts */,
+			);
+			name = Build;
+			sourceTree = "<group>";
+		};
+		A08CB6952243AB570003876C /* scripts */ = {
+			isa = PBXGroup;
+			children = (
+				A08CB6962243AB570003876C /* use_android_strings_in_zom.sh */,
+				A08CB6972243AB570003876C /* stringtool.sh */,
+				A08CB6982243AB570003876C /* genstrings.swift */,
+				A08CB6992243AB570003876C /* genstrings.sh */,
+			);
+			path = scripts;
 			sourceTree = "<group>";
 		};
 		E348AC5B6FDFD88B2C0C9521 /* Frameworks */ = {

--- a/Zom 2/AppDelegate.swift
+++ b/Zom 2/AppDelegate.swift
@@ -17,7 +17,19 @@ class AppDelegate: BaseAppDelegate {
     static let userDefaultsKeyMigratedZom1 = "migratedZom1"
     
     override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        
+
+// For debugging purposes: These are the folders, where all the stuff is stored.
+// You can have a look at it, while running in the simulator!
+//
+//        let fm = FileManager.default
+//
+//        if let appGroupId = Config.appGroupId,
+//            let container = fm.containerURL(forSecurityApplicationGroupIdentifier: appGroupId) {
+//            print(container)
+//        }
+//        print(fm.urls(for: .libraryDirectory, in: .userDomainMask))
+
+
         // Initialize theme
         let _ = Theme.shared
         

--- a/Zom 2/Base.lproj/LaunchScreen.storyboard
+++ b/Zom 2/Base.lproj/LaunchScreen.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
-    <device id="retina4_7" orientation="portrait">
+    <device id="retina5_9" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -15,21 +15,21 @@
             <objects>
                 <viewController id="01J-lp-oVM" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="z7e-fB-ltq">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pJE-Vo-8Tf">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="onboarding_logo" translatesAutoresizingMaskIntoConstraints="NO" id="sjG-tz-yq1">
-                                        <rect key="frame" x="87.5" y="99.5" width="200" height="249"/>
+                                        <rect key="frame" x="87.666666666666686" y="172" width="200" height="249"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="200" id="KWg-zf-bks"/>
                                             <constraint firstAttribute="height" constant="249" id="Qe6-91-u4t"/>
                                         </constraints>
                                     </imageView>
                                     <button hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6xw-Vt-SGn" userLabel="Skip Button">
-                                        <rect key="frame" x="172.5" y="408.5" width="30" height="30"/>
+                                        <rect key="frame" x="172.66666666666666" y="481" width="30" height="30"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                         <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <state key="normal" title="&gt;&gt;">
@@ -37,7 +37,7 @@
                                         </state>
                                     </button>
                                     <button hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Xfg-p2-fcm">
-                                        <rect key="frame" x="119.5" y="368.5" width="136" height="30"/>
+                                        <rect key="frame" x="119.66666666666669" y="441" width="136" height="30"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                         <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <state key="normal" title="WELCOME TO ZOM">
@@ -61,7 +61,7 @@
                         <constraints>
                             <constraint firstItem="pJE-Vo-8Tf" firstAttribute="trailing" secondItem="spn-4N-cTZ" secondAttribute="trailing" id="RlR-0C-Noq"/>
                             <constraint firstItem="pJE-Vo-8Tf" firstAttribute="top" secondItem="z7e-fB-ltq" secondAttribute="top" id="YYf-Wi-4Hw"/>
-                            <constraint firstItem="pJE-Vo-8Tf" firstAttribute="bottom" secondItem="spn-4N-cTZ" secondAttribute="bottom" id="kTx-zY-oc3"/>
+                            <constraint firstAttribute="bottom" secondItem="pJE-Vo-8Tf" secondAttribute="bottom" id="iaX-ED-CAO"/>
                             <constraint firstItem="pJE-Vo-8Tf" firstAttribute="leading" secondItem="spn-4N-cTZ" secondAttribute="leading" id="ozd-Cs-b6n"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="spn-4N-cTZ"/>
@@ -69,7 +69,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="53" y="375"/>
+            <point key="canvasLocation" x="52.173913043478265" y="375"/>
         </scene>
     </scenes>
     <resources>

--- a/Zom 2/Base.lproj/Onboarding.storyboard
+++ b/Zom 2/Base.lproj/Onboarding.storyboard
@@ -77,7 +77,7 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="EWK-cY-Xas" firstAttribute="bottom" secondItem="q6f-dL-u79" secondAttribute="bottom" id="QZ4-Ut-g0E"/>
+                            <constraint firstAttribute="bottom" secondItem="EWK-cY-Xas" secondAttribute="bottom" id="Tx8-Rs-o9z"/>
                             <constraint firstItem="EWK-cY-Xas" firstAttribute="trailing" secondItem="q6f-dL-u79" secondAttribute="trailing" id="mjv-rK-HFB"/>
                             <constraint firstItem="EWK-cY-Xas" firstAttribute="top" secondItem="1Um-Tm-AyR" secondAttribute="top" id="sX6-aL-cH3"/>
                             <constraint firstItem="EWK-cY-Xas" firstAttribute="leading" secondItem="q6f-dL-u79" secondAttribute="leading" id="sdR-GT-cRT"/>

--- a/Zom 2/Base.lproj/Onboarding.storyboard
+++ b/Zom 2/Base.lproj/Onboarding.storyboard
@@ -145,7 +145,7 @@
                     <navigationItem key="navigationItem" title="Add Account" id="Vpw-4f-Vbp">
                         <barButtonItem key="leftBarButtonItem" title="Cancel" id="U9e-l3-RWQ">
                             <connections>
-                                <action selector="cancel" destination="awu-JF-dR6" id="i2O-qk-7o1"/>
+                                <action selector="done" destination="awu-JF-dR6" id="zIC-O1-tXS"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>

--- a/Zom 2/Zom 2.entitlements
+++ b/Zom 2/Zom 2.entitlements
@@ -10,7 +10,7 @@
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.im.zom.messenger</string>
+		<string>$(KEANU_APP_GROUP)</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
- Fixed some UI Issues with iPhone X/XS... (bottom edge was not filled)
- Fixed a new incompatibility with Keanu (changed method name)
- Fixed CocoaPods warning
- Use constants from `Config.xcconfig` instead of hardcoded values in project config.

Sorry, the last one sets signing to "manual". But that's easy to fix: You just need to add the *name* of the certificates in `Config.xcconfig` like this:

```
PROVISIONING_PROFILE_MAIN_DEV =
PROVISIONING_PROFILE_SPECIFIER_MAIN_DEV = Keanu Dev
PROVISIONING_PROFILE_MAIN_RELEASE =
PROVISIONING_PROFILE_SPECIFIER_MAIN_RELEASE = Keanu Dist

PROVISIONING_PROFILE_SHARE_EXTENSION_DEV =
PROVISIONING_PROFILE_SPECIFIER_SHARE_EXTENSION_DEV = Keanu ShareExtension Dev
PROVISIONING_PROFILE_SHARE_EXTENSION_RELEASE =
PROVISIONING_PROFILE_SPECIFIER_SHARE_EXTENSION_RELEASE = Keanu ShareExtension Dist
```

If Xcode can't find the certs, go to "Preferences..." -> "Accounts" -> "Download Manual Profiles" or press "Download Profile..." in the "Provisioning Profile" dropdown.

After that, build should work again as expected.

But if you do this, every contributor can easily reconfigure for themselves to run on their own hardware device.